### PR TITLE
Limit layout scrolling to palette and canvas

### DIFF
--- a/layout.css
+++ b/layout.css
@@ -15,9 +15,9 @@
   .btn-primary{border-color:#93c5fd;background:#dbeafe}
   .btn-danger{border-color:#fca5a5;background:#fee2e2}
   .btn:disabled{opacity:.5;cursor:not-allowed}
-  .wrap{display:flex;gap:14px;padding:14px}
+  .wrap{display:flex;gap:14px;padding:14px;height:calc(100vh - 60px);overflow:hidden}
   /* パレット */
-  .palette{width:360px;flex:0 0 360px;border:1px solid #e5e7eb;border-radius:12px;padding:10px;background:#fff;align-self:flex-start}
+  .palette{width:360px;flex:0 0 360px;border:1px solid #e5e7eb;border-radius:12px;padding:10px;background:#fff;align-self:flex-start;overflow-y:auto}
   .palette h2{font-size:14px;margin:0 0 8px;color:#374151}
   .group-title{font-size:12px;color:#475569;font-weight:600;margin:8px 0 6px}
   .items{display:grid;gap:8px;margin-bottom:10px}
@@ -40,7 +40,7 @@
   .inspector-actions .spacer{flex:1; text-align:left; color:#475569; font-weight:600}
   .inspector-actions label{flex-direction:row; align-items:center; gap:6px; background:transparent; border:none; padding:0}
   /* ビューポート＆キャンバス */
-  .stage-viewport{position:relative;overflow:auto;border-radius:12px;flex:1;min-height:720px;background:#fff;}
+  .stage-viewport{position:relative;overflow:auto;border-radius:12px;flex:1;min-height:720px;background:#fff;height:100%;}
   .stage-wrap{position:relative;transform-origin:left top;}
   #stage{
     position:relative;


### PR DESCRIPTION
## Summary
- Fix wrap height and overflow to prevent body scrolling
- Enable palette and canvas to scroll independently

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e832518308323a30a519e4023a05d