### PR TITLE
feat: toggle palette visibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,10 +7,11 @@
 <title>レイアウトボード</title>
 <link rel="stylesheet" href="layout.css">
 </head>
-<body>
-  <header>
-    <!-- ファイル -->
-    <div class="group" title="エクスポート/インポート/画像保存">
+  <body>
+    <header>
+      <button class="btn" id="togglePalette">パレット</button>
+      <!-- ファイル -->
+      <div class="group" title="エクスポート/インポート/画像保存">
       <span class="group-label">ファイル</span>
       <button class="btn" id="btnNew">新規</button>
       <button class="btn" id="btnExport">エクスポート</button>

--- a/layout.css
+++ b/layout.css
@@ -15,9 +15,10 @@
   .btn-primary{border-color:#93c5fd;background:#dbeafe}
   .btn-danger{border-color:#fca5a5;background:#fee2e2}
   .btn:disabled{opacity:.5;cursor:not-allowed}
-  .wrap{display:flex;gap:14px;padding:14px;height:calc(100vh - 60px);overflow:hidden}
+  .wrap{display:flex;gap:14px;padding:14px;height:calc(100vh - 60px);overflow:hidden;flex:1}
   /* パレット */
   .palette{width:360px;flex:0 0 360px;border:1px solid #e5e7eb;border-radius:12px;padding:10px;background:#fff;align-self:flex-start;overflow-y:auto}
+  .palette.collapsed{display:none}
   .palette h2{font-size:14px;margin:0 0 8px;color:#374151}
   .group-title{font-size:12px;color:#475569;font-weight:600;margin:8px 0 6px}
   .items{display:grid;gap:8px;margin-bottom:10px}

--- a/layout.js
+++ b/layout.js
@@ -13,6 +13,14 @@
     var connLayer = $('#connLayer');
     var marquee = $('#marquee');
 
+    var palettePane = $('.palette');
+    var toggleBtn = $('#togglePalette');
+    if(toggleBtn){
+      toggleBtn.addEventListener('click', function(){
+        palettePane.classList.toggle('collapsed');
+      });
+    }
+
     /* ===== Undo/Redo History ===== */
     var hist = [];      // Array<stateObj>
     var redoStack = [];


### PR DESCRIPTION
## Summary
- add palette toggle button to header
- hide palette with collapsed styles so canvas can fill width
- handle button click to toggle collapsed class on palette

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e95614bfc83239791680067a4c714