### PR TITLE
ラップ領域の固定高さを廃止しスクロールを統一

### DIFF
--- a/layout.css
+++ b/layout.css
@@ -15,9 +15,9 @@
   .btn-primary{border-color:#93c5fd;background:#dbeafe}
   .btn-danger{border-color:#fca5a5;background:#fee2e2}
   .btn:disabled{opacity:.5;cursor:not-allowed}
-  .wrap{display:flex;gap:14px;padding:14px;height:calc(100vh - 60px);overflow:hidden}
+  .wrap{display:flex;gap:14px;padding:14px;min-height:calc(100vh - 60px)}
   /* パレット */
-  .palette{width:360px;flex:0 0 360px;border:1px solid #e5e7eb;border-radius:12px;padding:10px;background:#fff;align-self:flex-start;overflow-y:auto}
+  .palette{width:360px;flex:0 0 360px;border:1px solid #e5e7eb;border-radius:12px;padding:10px;background:#fff;align-self:flex-start;overflow:visible}
   .palette h2{font-size:14px;margin:0 0 8px;color:#374151}
   .group-title{font-size:12px;color:#475569;font-weight:600;margin:8px 0 6px}
   .items{display:grid;gap:8px;margin-bottom:10px}


### PR DESCRIPTION
## 概要
- `.wrap` の `height:calc(100vh - 60px)` と `overflow:hidden` を削除し、必要な最低高さを `min-height` に変更
- `.palette` の `overflow-y:auto` を `overflow:visible` に変更し、左欄をページスクロールに追従

## テスト
- `npm test` (package.json が存在しないため実行不可)
- `node` + `puppeteer` によるスクロール確認 (必要ライブラリ欠如で失敗)


------
https://chatgpt.com/codex/tasks/task_e_689e955f8be08323b58c1e47c861575c