### PR TITLE
ラップ領域の固定高さを削除しスクロールを統一

### DIFF
--- a/layout.css
+++ b/layout.css
@@ -15,9 +15,9 @@
   .btn-primary{border-color:#93c5fd;background:#dbeafe}
   .btn-danger{border-color:#fca5a5;background:#fee2e2}
   .btn:disabled{opacity:.5;cursor:not-allowed}
-  .wrap{display:flex;gap:14px;padding:14px;height:calc(100vh - 60px);overflow:hidden;flex:1}
+  .wrap{display:flex;gap:14px;padding:14px;flex:1}
   /* パレット */
-  .palette{width:360px;flex:0 0 360px;border:1px solid #e5e7eb;border-radius:12px;padding:10px;background:#fff;align-self:flex-start;overflow-y:auto}
+  .palette{width:360px;flex:0 0 360px;border:1px solid #e5e7eb;border-radius:12px;padding:10px;background:#fff;align-self:flex-start}
   .palette.collapsed{display:none}
   .palette h2{font-size:14px;margin:0 0 8px;color:#374151}
   .group-title{font-size:12px;color:#475569;font-weight:600;margin:8px 0 6px}


### PR DESCRIPTION
## Summary
- `.wrap` の固定高さと overflow を削除し、ページ全体のスクロールに合わせる
- `.palette` の overflow を解除し、左欄とキャンバスのスクロールを統一

## Testing
- `node --check layout.js`
- `npm test` *(package.json が存在しないため実行不可)*

------
https://chatgpt.com/codex/tasks/task_e_689e94f60bcc8323bbf2312885508a99